### PR TITLE
add support drop:after for droppable element

### DIFF
--- a/javascripts/jtrainer/current/js/additions/drag-drops.js
+++ b/javascripts/jtrainer/current/js/additions/drag-drops.js
@@ -20,5 +20,6 @@ function makeDroppable(elementName) {
             parent.attr("value", parentValue.replace("," + answerValue, "").replace(answerValue + ",", "").replace(answerValue, ""));
             $(this).attr('style', 'position:relative').appendTo('div.draggables[name="' + parentSelector + '"]').draggable("enable").unbind('click');
         });
+        $(this).trigger('drop:after')
     }});
 }


### PR DESCRIPTION
Problem: there is no sаfe way  to create user drop event for droppable element, that's  fire after standard event. All possible hack to do so is base on internal methods of JQuery, which can be changed in future versions. So I'm add drop:after event for droppable. This event fire at the end of standard drop event.
