### PR TITLE
Migrate from element.attr('value') to element.val() as value storage …

### DIFF
--- a/javascripts/jtrainer/current/js/additions/drag-drops.js
+++ b/javascripts/jtrainer/current/js/additions/drag-drops.js
@@ -1,3 +1,12 @@
+$.valHooks.div = {
+	get: function(elem){
+		return $(elem).attr('value');
+	},
+	set: function(elem,value){
+		$(elem).attr('value',value);
+	}
+}
+
 function makeDraggable(elementName) {
     $('div.draggables[name="' + elementName + '"] div.draggable').draggable({
         revert: true
@@ -11,13 +20,13 @@ function makeDroppable(elementName) {
         ui.draggable.appendTo('div.droppable[name="' + elementName + '"]');
         ui.draggable.draggable("disable");
         ui.draggable.appendTo('div.droppable[name="' + elementName + '"]').removeAttr('style', '');
-        var v = ($(this).attr('value') || '');
-        $(this).attr('value', (v + (v.length > 0 ? ',' : '') + ui.draggable.attr('value')));
+        var v = ($(this).val() || '');
+        $(this).val(v + (v.length > 0 ? ',' : '') + ui.draggable.val());
         ui.draggable.click(function () {
             var parent = $(this).closest("div.droppable");
-            var answerValue = $(this).attr("value");
-            var parentValue = parent.attr("value");
-            parent.attr("value", parentValue.replace("," + answerValue, "").replace(answerValue + ",", "").replace(answerValue, ""));
+            var answerValue = $(this).val();
+            var parentValue = parent.val();
+            parent.val(parentValue.replace("," + answerValue, "").replace(answerValue + ",", "").replace(answerValue, ""));
             $(this).attr('style', 'position:relative').appendTo('div.draggables[name="' + parentSelector + '"]').draggable("enable").unbind('click');
         });
     }});


### PR DESCRIPTION
…getter/setter for draggable/droppable

Using val() is more obvious then attr('value'), especially for div element. Attribute 'value' value is used as backend for data storing. So it 
must not be any backward capability issues. Validator use both val() and attr('value') way to get element value, so it might work well to.
